### PR TITLE
Different method for setting password of hacluster

### DIFF
--- a/scripts/sleha-functions
+++ b/scripts/sleha-functions
@@ -196,7 +196,10 @@ init_cluster_local()
 	local pass_msg
 	if [ "$ps" != "PS" ]; then
 		log ': Resetting password of hacluster user'
-		echo "linux" | passwd --stdin hacluster > /dev/null
+		passwd > /dev/null 2>&1 <<EOF
+linux
+linux
+EOF
 		pass_msg=", password 'linux'"
 	fi
 


### PR DESCRIPTION
It seems that in openSUSE 12.3, passwd no longer accepts --stdin
as a command line parameter. This should work even without the
command line flag support.

One problem is that passwd writes quite a bit of output to stderr,
so I'm redirecting both stdin and stderr to /dev/null. If there is
a problem with setting the password, it will be more difficult to
figure out.
