### PR TITLE
Bug: Reset password of correct user

### DIFF
--- a/scripts/sleha-functions
+++ b/scripts/sleha-functions
@@ -200,7 +200,7 @@ init_cluster_local()
 linux
 linux
 EOF
-		[ $? -ne 0 ] && warn ": Failed to reset password of hacluster user"
+		[ $? -ne 0 ] && warn "Failed to reset password of hacluster user"
 		pass_msg=", password 'linux'"
 	fi
 


### PR DESCRIPTION
Fixes previous pull request.

Make sure to set the password of hacluster, not root.
Also, log if passwd returns != 0.
