### PR TITLE
Run removal commands in bash shell to avoid prompts from zsh (bnc#862572)

### DIFF
--- a/scripts/ha-cluster-remove
+++ b/scripts/ha-cluster-remove
@@ -143,9 +143,9 @@ remove_cluster()
 			|| error "stop the service corosync on $SEED_HOST failed"
 
 		#delete the configure file from the node $SEED_HOST
-		invoke ssh root@$HOST "rm -f $SYSCONFIG_SBD $CSYNC2_CFG \
+		invoke ssh root@$HOST "bash -c \"rm -f $SYSCONFIG_SBD $CSYNC2_CFG \
 				$COROSYNC_CONF $CSYNC2_KEY \
-				&& rm -f /var/lib/heartbeat/crm/* /var/lib/pacemaker/cib/*" \
+				&& rm -f /var/lib/heartbeat/crm/* /var/lib/pacemaker/cib/*\"" \
 				|| error "Delete the configure files failed"
 	else
 		#check node status


### PR DESCRIPTION
If the root user has their shell set to zsh, rm -f may insist on
prompting before removing with wildcards.
