### PR TITLE
Use netstat to guess at the default route interface (bnc#854172)

### DIFF
--- a/scripts/ha-cluster-functions
+++ b/scripts/ha-cluster-functions
@@ -36,7 +36,7 @@ declare -r SYSCONFIG_FW_CLUSTER=/etc/sysconfig/SuSEfirewall2.d/services/cluster
 
 declare BE_QUIET=false
 declare YES_TO_ALL=false
-declare NET_IF=eth0
+declare NET_IF="$(netstat -nr | grep '^0.0.0.0' | awk '{print ($(NF))}' 2>/dev/null)"
 declare IP_ADDRESS
 declare IP_NETWORK
 


### PR DESCRIPTION
Since the name of the default network interface is no longer
likely to be eth0, use netstat to make an educated guess.
