### PR TITLE
Exit with error if ha-cluster-join is called over ssh without -t (bnc#892702)

### DIFF
--- a/scripts/ha-cluster-functions
+++ b/scripts/ha-cluster-functions
@@ -470,6 +470,14 @@ check_prereqs()
 	init_firewall
 }
 
+check_tty()
+{
+	# Check for pseudo-tty: Cannot display read prompts without a TTY (bnc#892702)
+	if ! tty -s; then
+		error "No pseudo-tty detected! Use -t option to ssh if calling remotely."
+	fi
+}
+
 init()
 {
 	log_start

--- a/scripts/ha-cluster-init
+++ b/scripts/ha-cluster-init
@@ -627,6 +627,7 @@ fi
 
 # Need hostname resolution to work, want NTP (but don't block ssh_remote or csync2_remote)
 if [ "$stage" != "ssh_remote" -a "$stage" != "csync2_remote" ]; then
+	check_tty
 	check_prereqs
 fi
 

--- a/scripts/ha-cluster-join
+++ b/scripts/ha-cluster-join
@@ -258,6 +258,7 @@ if [ "$1" != "ssh" -a "$1" != "csync2" -a "$1" != "ssh_merge" ]; then
 	[ $rc -eq 0 ] && error "Cluster is currently active - can't run"
 fi
 
+check_tty
 # Need hostname resolution to work, want NTP
 check_prereqs
 

--- a/scripts/ha-cluster-remove
+++ b/scripts/ha-cluster-remove
@@ -228,6 +228,7 @@ done
 
 [ -n "$SEED_HOST" ] || _die "No existing IP/hostname specified (use -c option)"
 
+check_tty
 init
 remove_ssh
 remove_hostname_check


### PR DESCRIPTION
read -p needs a pseudo-tty to display the prompt, and calling ssh recursively without a tty is unlikely to work.

See: http://stackoverflow.com/questions/3018036/missing-read-prompt-in-bash-when-using-ssh