### PR TITLE
Use crm_node when deciding to reset no-quorum-policy=ignore (boo#923372)

### DIFF
--- a/scripts/ha-cluster-join
+++ b/scripts/ha-cluster-join
@@ -219,7 +219,7 @@ join_cluster()
 	invoke corosync-cfgtool -R
 
 	# Ditch no-quorum-policy=ignore if we're going over two nodes
-	if [ $new_quorum -gt 2 ] && crm configure show | grep -q 'no-quorum-policy=.*ignore' ; then
+	if [ $(crm_node -l | sed '/^$/d' | wc -l) -gt 2 ] && crm configure show | grep -q 'no-quorum-policy=.*ignore' ; then
 		invoke crm_attribute --attr-name no-quorum-policy --delete-attr
 	fi
 }


### PR DESCRIPTION
Up-ported from the old branch. I'm actually not sure this is as relevant here, what do you think? Also, shouldn't merge this until the fix is confirmed to really work.

Previous to this, corosync.conf is modified to set expected_votes and two_node. That part /may/ need fixing as well...