### PR TITLE
Sync entire /etc/booth directory (fate#319318)

### DIFF
--- a/scripts/ha-cluster-init
+++ b/scripts/ha-cluster-init
@@ -137,7 +137,7 @@ group ha_group
 {
 	key /etc/csync2/key_hagroup;
 	host $(hostname);
-	include /etc/booth/booth.conf;
+	include /etc/booth;
 	include /etc/corosync/corosync.conf;
 	include /etc/corosync/authkey;
 	include /etc/csync2/csync2.cfg;


### PR DESCRIPTION
Key files may be added in the /etc/booth directory, so we should
sync all of the files there.