### PR TITLE
Check corosync.conf before access (bsc#943227)

### DIFF
--- a/scripts/ha-cluster-join
+++ b/scripts/ha-cluster-join
@@ -199,6 +199,10 @@ join_cluster()
 
 	# Bump expected_votes in corosync.conf
 	# TODO(must): this is rather fragile (see related code in ha-cluster-remove)
+
+	# If COROSYNC_CONF doesn't exist or is empty, we will fail here. (bsc#943227)
+	[ ! -s $COROSYNC_CONF ] && error "$COROSYNC_CONF is not readable. Please ensure that hostnames are resolvable."
+
 	local tmp_conf=${COROSYNC_CONF}.$$
 	local new_quorum=$(awk -F[^0-9] '/^[[:space:]]*expected_votes/ { print $NF + 1 };' $COROSYNC_CONF)
 	local two_node=0


### PR DESCRIPTION
If corosync.conf does not exist or is an empty file, which may happen
if hostnames haven't been properly configured, the following check
for expected_votes will fail. By checking here, we can print a more
informative error message.