### PR TITLE
Better corosync defaults (bsc#1001164)

### DIFF
--- a/scripts/ha-cluster-functions
+++ b/scripts/ha-cluster-functions
@@ -29,6 +29,7 @@ declare -r INVOCATION=$(printf '%q ' "$0" "$@")
 declare -r LOG_FILE=/var/log/ha-cluster-bootstrap.log
 declare -r CSYNC2_KEY=/etc/csync2/key_hagroup
 declare -r CSYNC2_CFG=/etc/csync2/csync2.cfg
+declare -r COROSYNC_AUTH=/etc/corosync/authkey
 declare -r COROSYNC_CONF=/etc/corosync/corosync.conf
 declare -r SYSCONFIG_SBD=/etc/sysconfig/sbd
 declare -r SYSCONFIG_FW=/etc/sysconfig/SuSEfirewall2

--- a/scripts/ha-cluster-init
+++ b/scripts/ha-cluster-init
@@ -243,13 +243,17 @@ Configure Corosync (unicast):
 
 totem {
 	version:	2
-
-	crypto_cipher:	none
-	crypto_hash:	none
-
-	secauth:	off
+	secauth:	on
+	crypto_hash:	sha1
+	crypto_cipher:	aes256
 	cluster_name:	hacluster
 	clear_node_high_bit: yes
+
+	token:		5000
+	token_retransmits_before_loss_const: 10
+	join:		60
+	consensus:	6000
+	max_messages:	20
 
 	interface {
 		ringnumber:	0
@@ -334,21 +338,17 @@ Configure Corosync:
 
 totem {
 	version:	2
-	secauth:	off
+	secauth:	on
+	crypto_hash:	sha1
+	crypto_cipher:	aes256
 	cluster_name:	hacluster
 	clear_node_high_bit: yes
 
-# Following are old corosync 1.4.x defaults from SLES
-#	token:		5000
-#	token_retransmits_before_loss_const: 10
-#	join:		60
-#	consensus:	6000
-#	vsftype:	none
-#	max_messages:	20
-#	threads:	0
-
-	crypto_cipher:	none
-	crypto_hash:	none
+	token:		5000
+	token_retransmits_before_loss_const: 10
+	join:		60
+	consensus:	6000
+	max_messages:	20
 
 	interface {
 		ringnumber:	0
@@ -385,8 +385,21 @@ END
 	invoke csync2 -xv $COROSYNC_CONF
 }
 
+init_corosync_auth()
+{
+	# generate the corosync authkey
+	if [ -f "$COROSYNC_AUTH" ]; then
+		confirm \
+			"$COROSYNC_AUTH already exists - overwrite?" || return
+		invoke rm -f "$COROSYNC_AUTH"
+	fi
+	invoke corosync-keygen -l
+}
+
 init_corosync()
 {
+	init_corosync_auth
+
 	if dmidecode -s system-version | grep '\<.*\.amazon\>'; then
 		init_corosync_unicast
 	elif $COROSYNC_UNICAST; then


### PR DESCRIPTION
* Set corosync defaults as they were in SLE 11

* Generate authkey and enable authentication/encryption by default